### PR TITLE
Add user creation API endpoint

### DIFF
--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -1,0 +1,26 @@
+module Api
+  class UserController < ApplicationController
+    before_action :validate_params, only: :create
+
+    def create
+      user = User.new(user_params)
+      if user.save
+        render json: { message: "User created successfully" }, status: :created
+      else
+        render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def user_params
+      params.permit(:email, :password)
+    end
+
+    def validate_params
+      if user_params[:email].blank? || user_params[:password].blank?
+        render json: { errors: [ "Email and password are required" ] }, status: :bad_request
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,9 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    post "user", to: "user#create"
+  end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 end

--- a/spec/controllers/api/user_controller_spec.rb
+++ b/spec/controllers/api/user_controller_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe Api::UserController, type: :controller do
+  describe "POST #create" do
+    let(:valid_attributes) { attributes_for(:user) }
+    let(:invalid_attributes) { { email: "test@example.com" } }
+
+    context "with valid parameters" do
+      it "creates a new user and returns created" do
+        expect {
+          post :create, params: valid_attributes
+        }.to change(User, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(parsed_response["message"]).to eq("User created successfully")
+      end
+    end
+
+    context "with missing email or password" do
+      it "returns a bad request error" do
+        post :create, params: invalid_attributes
+        expect(response).to have_http_status(:bad_request)
+        expect(parsed_response["errors"]).to eq([ "Email and password are required" ])
+      end
+    end
+
+    context "when user email already exists" do
+      before { create(:user, email: valid_attributes[:email]) }
+
+      it "returns unprocessable entity error" do
+        post :create, params: valid_attributes
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response["errors"]).to eq([ "Email has already been taken" ])
+      end
+    end
+
+    context "when password is invalid" do
+      let(:invalid_password_attributes) { attributes_for(:user, password: "short") }
+
+      it "returns unprocessable entity error" do
+        post :create, params: invalid_password_attributes
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(parsed_response["errors"]).to eq([ "Password must be at least 8 characters and include at least one letter and one number" ])
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,23 +46,8 @@ RSpec.configure do |config|
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 
-  # RSpec Rails uses metadata to mix in different behaviours to your tests,
-  # for example enabling you to call `get` and `post` in request specs. e.g.:
-  #
-  #     RSpec.describe UsersController, type: :request do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://rspec.info/features/7-1/rspec-rails
-  #
-  # You can also this infer these behaviours automatically by location, e.g.
-  # /spec/models would pull in the same behaviour as `type: :model` but this
-  # behaviour is considered legacy and will be removed in a future version.
-  #
-  # To enable this behaviour uncomment the line below.
-  # config.infer_spec_type_from_file_location!
-
+  # Include parsed_response helper for controller specs
+  config.include ResponseParsingHelper, type: :controller
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:

--- a/spec/support/response_parsing_helper.rb
+++ b/spec/support/response_parsing_helper.rb
@@ -1,0 +1,5 @@
+module ResponseParsingHelper
+  def parsed_response
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
Adds a POST endpoint at `/api/users` to handle user signup.

It will return 201 - Created if email is not taken yet and password attends the requirements ([more details here](https://github.com/seidelmaycon/game-api/pull/1)).
It will return 422 - Unprocessable Entity if email already exists or password is not valid
- Expected error messages are:
  - `{"errors":["Email has already been taken","Password must be at least 8 characters and include at least one letter and one number"]}`
It will return 400 - Bad Request if both (email, password) params are not present.


Example of valid request:
```bash
curl -X POST http://localhost:3000/api/user \
  -H "Content-Type: application/json" \
  -d '{"email": "example@gmail.com", "password": "password123"}
```