### PR TITLE
Add User show endpoint for details and stats

### DIFF
--- a/app/controllers/api/user_controller.rb
+++ b/app/controllers/api/user_controller.rb
@@ -3,6 +3,11 @@ module Api
     skip_before_action :authenticate_user!, only: :create
     before_action :validate_params, only: :create
 
+
+    def show
+      render json: current_user
+    end
+
     def create
       user = ::User.new(user_params)
       if user.save

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,9 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :email, :stats
+
+  def stats
+    {
+      total_games_played: object.game_events.count
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     post "user", to: "user#create"
+    get "user", to: "user#show"
     post "sessions", to: "sessions#create"
     namespace :user do
       post "game_events", to: "game_events#create"

--- a/spec/controllers/api/user_controller_spec.rb
+++ b/spec/controllers/api/user_controller_spec.rb
@@ -1,6 +1,38 @@
 require "rails_helper"
 
 describe Api::UserController, type: :controller do
+  describe "GET #show" do
+    context "when authenticated" do
+      let(:user) { create(:user) }
+      let!(:game_events) { create_list(:game_event, 5, user: user) }
+      let!(:another_user_game_events) { create_list(:game_event, 3, user: create(:user)) }
+      before { set_auth_header_for(user) }
+
+      it "returns a 200 response with the current user" do
+        get :show, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response).to eq({
+          "user" => {
+            "id" => user.id,
+            "email" => user.email,
+            "stats" => {
+              "total_games_played" => 5
+            }
+          }
+        })
+      end
+    end
+
+    context "when not authenticated" do
+      it "returns a 401 unauthorized response" do
+        get :show, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+
   describe "POST #create" do
     let(:valid_attributes) { attributes_for(:user) }
     let(:invalid_attributes) { { email: "test@example.com" } }


### PR DESCRIPTION
## Adds User Details and Stats endpoint
1. Creates GET `/api/user` endpoint;
  - It expects a GET request with authentication headers;
  - Returns 401 if bearer token is not valid;
  - Returns the status with how many games the signed user user played.

Expected `200` response:
```json
{
  "user": {
    "id": 1,
    "email": "mseidel@gmail.com",
    "stats": {
      "total_games_played": 2
    }
  }
}
```
